### PR TITLE
Ensure that `project_id` is set for meters

### DIFF
--- a/ssc-billing-logger.py
+++ b/ssc-billing-logger.py
@@ -324,6 +324,7 @@ class MeterSet:
         meters = json.loads(ar.text)
         if len(meters) == 0:
             sys.stderr.write("[W1000] Ceilometer meters collection is empty, services may need restarting\n");
+        meters = [m for m in meters if m['project_id'] is not None]
 
         self.resource_infos = {}
         for meter in meters:


### PR DESCRIPTION
In some circumstances the Ceilometer may report meters with a `project_id` of `None`.
As we have a hard requirement on this being set, filter out the bogus entries.